### PR TITLE
Update vue-mode.el

### DIFF
--- a/vue-mode.el
+++ b/vue-mode.el
@@ -42,7 +42,7 @@
                                  (es6    . js-mode)
                                  (coffee . coffee-mode)
                                  ))
-                    ("style"  . ((default . css-mode)
+                    ("style"  . ((default . stylus-mode)
                                  (css    . css-mode  )
                                  (stylus . stylus-mode)
                                  (less   . less-css-mode)


### PR DESCRIPTION
原来的css-mode 没法高亮 @import '...'

```stylus
<style lang="stylus">
@import "../variables.styl"
.comment-content
  margin 0 0 16px 24px
  word-wrap break-word
  code
    white-space pre-wrap

.child-comments
  margin 8px 0 8px 22px
</style>
```

改成默认 stylus-mode 就行了，而且兼容普通的css-mode。

样例看这个文件

https://github.com/vuejs/vue-hackernews/blob/gh-pages/src/components/ItemView.vue
